### PR TITLE
Fix premium expiration and boolean handling

### DIFF
--- a/commands/alt detector/abypass.js
+++ b/commands/alt detector/abypass.js
@@ -53,10 +53,10 @@ module.exports = class extends Command {
           }
           
           let oldAllowedAlts = db.allowedAlts //[]
-          if(guildDB.isPremium === "false") {
+          if(!guildDB.isPremium) {
           if(oldAllowedAlts.length === 10) return message.channel.send(new discord.MessageEmbed().setColor(client.color.red).setDescription(language.abypassNotPremium10))
           }
-          if(guildDB.isPremium === "true") {
+          if(guildDB.isPremium) {
           if(oldAllowedAlts.length === 50) return message.channel.send(new discord.MessageEmbed().setColor(client.color.red).setDescription(language.abypassNotPremium10.replace("10", "50")))
           }
           oldAllowedAlts.push(u.id)

--- a/commands/applications/approve.js
+++ b/commands/applications/approve.js
@@ -25,7 +25,7 @@ module.exports = class extends Command {
     });
     const language = require(`../../data/language/${guildDB.language}.json`)
     
-    if(guildDB.isPremium === "false"){
+    if(!guildDB.isPremium){
 
 message.channel.send(new discord.MessageEmbed().setColor(message.guild.me.displayHexColor).setDescription(`${message.client.emoji.fail} | ${language.approvepremium}.\n\n[Check Premium Here](https://pogy.xyz/premium)`))
 

--- a/commands/applications/decline.js
+++ b/commands/applications/decline.js
@@ -24,7 +24,7 @@ module.exports = class extends Command {
         guildId: message.guild.id
     });
     const language = require(`../../data/language/${guildDB.language}.json`)
-        if(guildDB.isPremium === "false"){
+        if(!guildDB.isPremium){
 
 message.channel.send(new discord.MessageEmbed().setColor(message.guild.me.displayHexColor).setDescription(`${message.client.emoji.fail} | ${language.approvepremium}.\n\n[Check Premium Here](https://pogy.xyz/premium)`))
 

--- a/commands/config/autoresponse.js
+++ b/commands/config/autoresponse.js
@@ -50,7 +50,7 @@ module.exports = class extends Command {
       if (content.length > 2000) return message.channel.send(`${message.client.emoji.fail} ${language.cc2}`);
 
 
-if(guildDB.isPremium === "false"){
+if(!guildDB.isPremium){
   const conditional = {
    guildId: message.guild.id
 }

--- a/commands/config/customcommand.js
+++ b/commands/config/customcommand.js
@@ -51,7 +51,7 @@ module.exports = class extends Command {
   
       if (this.client.commands.get(namee) || this.client.aliases.get(namee)) return message.channel.send(`That command is already an existing bot command!`);
 
-if(guildDB.isPremium === "false"){
+if(!guildDB.isPremium){
   const conditional = {
    guildId: message.guild.id
 }

--- a/commands/reactionrole/rrdirectmessages.js
+++ b/commands/reactionrole/rrdirectmessages.js
@@ -34,7 +34,7 @@ module.exports = class extends Command {
       let success = message.client.emoji.success
       const prefix = guildDB.prefix;
 
-      if(guildDB.isPremium == "false"){
+      if(!guildDB.isPremium){
       return message.channel.send(new MessageEmbed().setColor(message.guild.me.displayHexColor).setDescription(`${fail} Slow down here, the current command is only for premium guilds.\n\n[Check Premium Here](https://pogy.xyz/premium)`))}
 
   const missingPermEmbed = new MessageEmbed()

--- a/commands/utility/poll.js
+++ b/commands/utility/poll.js
@@ -92,7 +92,7 @@ const text = args.slice(0).join(' ')
 let msg = await message.channel.send({ embed: embed }).catch(() => {});
 
         if (timedPoll) {
-          if(guildDB.isPremium === "false"){
+          if(!guildDB.isPremium){
 if(msg){
 msg.delete().catch(()=>{})
 }

--- a/commands/utility/redeem.js
+++ b/commands/utility/redeem.js
@@ -28,8 +28,7 @@ module.exports = class extends Command {
 
     if(!code) return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} Please Specify a code to redeem`))
     
-    if(guildDB.isPremium === "true") {
-
+    if (guildDB.isPremium) {
       return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} the current guild is already premium`))
     }
 
@@ -39,10 +38,14 @@ module.exports = class extends Command {
 
     if(premium){
 
+if (Number(premium.expiresAt) < Date.now()) {
+  return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} This code has expired`))
+}
+
 const expires = moment(Number(premium.expiresAt)).format("dddd, MMMM Do YYYY HH:mm:ss")
 
 
-    guildDB.isPremium = "true";
+    guildDB.isPremium = true;
     guildDB.premium.redeemedBy.id = message.author.id;
     guildDB.premium.redeemedBy.tag = message.author.tag;
     guildDB.premium.redeemedAt = Date.now()

--- a/commands/utility/report.js
+++ b/commands/utility/report.js
@@ -145,7 +145,7 @@ guildDB.report.reportCase =  serverCase + 1;
 await guildDB.save().catch(()=>{})
 
 channel.send(reportEmbed1).then(async(reportEmbed) => {
-if(guildDB.isPremium == "true"){
+if(guildDB.isPremium){
 if(guildDB.report.upvote == "true"){
   if(guildDB.report.reaction == "1"){
 
@@ -235,7 +235,7 @@ let reportEmbed1 = new MessageEmbed()
 guildDB.report.reportCase =  serverCase + 1;
 await guildDB.save().catch(()=>{})
 channel.send(reportEmbed1).then(async(reportEmbed) => {
-if(guildDB.isPremium == "true"){
+if(guildDB.isPremium){
 if(guildDB.report.upvote == "true"){
   if(guildDB.report.reaction == "1"){
 reportEmbed.react('⬆️').catch(()=>{})

--- a/commands/utility/suggest.js
+++ b/commands/utility/suggest.js
@@ -81,7 +81,7 @@ let embed = new discord.MessageEmbed()
 
 
 
-  if(guildDB.isPremium == "false"){
+  if(!guildDB.isPremium){
   channel.send(embed).catch(err => {return message.channel.send(`${language.suggesting5}`)})
   .then(async(sug) => {
    
@@ -92,7 +92,7 @@ let embed = new discord.MessageEmbed()
   sug.react("790491137289879583").catch(() => {})
   
   })
-  } else if(guildDB.isPremium == "true"){
+  } else if(guildDB.isPremium){
    let member = message.member
    const description = guildDB.suggestion.description || `{suggestion}`;
    const footer = guildDB.suggestion.footer || `suggested by {user_tag}`

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -733,7 +733,7 @@ const now = new Date();
 let DDate = date.format(now, 'YYYY/MM/DD HH:mm:ss');
  member.send(new Discord.MessageEmbed().setDescription(`**Congratulations!**\n\n**${guild.name}** Is now a premium guild! Thanks a ton!\n\nIf you have any questions please contact me [here](https://discord.gg/FqdH4sfKBg)\n\n__**Reciept:**__\n**Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${guild.name}\n**Guild ID:** ${guild.id}\n\n**Please make sure to keep this information safe, you might need it if you ever wanna refund / transfer servers.**\n\n**Expires At:** ${expires}`).setColor('GREEN').setFooter(guild.name)).catch(()=>{});
 
-  storedSettings.isPremium = "true";
+  storedSettings.isPremium = true;
        storedSettings.premium.redeemedBy.id = member.id;
        storedSettings.premium.redeemedBy.tag = member.user.tag;
        storedSettings.premium.redeemedAt = Date.now()
@@ -3620,7 +3620,7 @@ storedSettings.reactionColor = data.reactionrolescolor;
       // rr dms
       let checkrrDms = req.body["rrDM"];
 
-if(storedSettings.isPremium == "false"){
+if(storedSettings.isPremium === false){
   storedSettings.reactionDM = true
 } else {
   
@@ -3836,7 +3836,7 @@ if(maintenance && maintenance.toggle == "true") {
         if (client.commands.get(check) || client.aliases.get(check)) return;
         const content = JSON.stringify(data)
         if (!content) return;
-if(storedSettings.isPremium === "false"){
+if(storedSettings.isPremium === false){
   const conditional = {
    guildId: guild.id
 }
@@ -4193,7 +4193,7 @@ In the mean time, please explain your issue below`;
         // close ticket
         let checkPing2 = req.body["ticketClose"];
 
-        if (storedSettings.isPremium == "false") {
+        if (storedSettings.isPremium === false) {
           ticketSettings.ticketClose = true;
         } else {
           if (checkPing2) {
@@ -4260,7 +4260,7 @@ In the mean time, please explain your issue below`;
 
             let ticketReaction = data.ticketReaction;
 
-            if (storedSettings.isPremium == "false") ticketReaction = `🎫`;
+            if (storedSettings.isPremium === false) ticketReaction = `🎫`;
 
 
             if (!embedColor || !reactionTitle || !reactionDescription || !ticketChannel || !ticketReaction) {
@@ -4282,7 +4282,7 @@ In the mean time, please explain your issue below`;
               ticketSettings.ticketTimestamp = false
             }
 
-            if (storedSettings.isPremium == "false") {
+            if (storedSettings.isPremium === false) {
               ticketSettings.ticketFooter = "Powered by Pogy.xyz";
             } else {
               let checkFooter2 = req.body["reactionfooterEmbed"];
@@ -4308,7 +4308,7 @@ In the mean time, please explain your issue below`;
 
 
             let footer = "Powered by Pogy.xyz";
-            if (storedSettings.isPremium == "true") footer = reactionFooter;
+            if (storedSettings.isPremium === true) footer = reactionFooter;
 
 
 
@@ -4319,7 +4319,7 @@ In the mean time, please explain your issue below`;
               .setColor(embedColor)
               .setDescription(reactionDescription)
 
-            if (storedSettings.isPremium == "false") {
+            if (storedSettings.isPremium === false) {
               ticketEmbed.setFooter(`Powered by Pogy.xyz`)
             } else {
 
@@ -4342,27 +4342,27 @@ In the mean time, please explain your issue below`;
             let emoji = data.ticketReaction;
 
 
-            if (data.ticketReaction == "ticketReaction2" && storedSettings.isPremium == "true") {
+            if (data.ticketReaction == "ticketReaction2" && storedSettings.isPremium === true) {
               emoji = "🎟️";
-            } else if (data.ticketReaction == "✅" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "✅" && storedSettings.isPremium === true) {
               emoji = "✅";
-            } else if (data.ticketReaction == "📻" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📻" && storedSettings.isPremium === true) {
               emoji = "📻";
-            } else if (data.ticketReaction == "☑️" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "☑️" && storedSettings.isPremium === true) {
               emoji = "☑️";
-            } else if (data.ticketReaction == "📲" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📲" && storedSettings.isPremium === true) {
               emoji = "📲";
-            } else if (data.ticketReaction == "📟" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📟" && storedSettings.isPremium === true) {
               emoji = "📟";
-            } else if (data.ticketReaction == "🆕" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "🆕" && storedSettings.isPremium === true) {
               emoji = "🆕";
-            } else if (data.ticketReaction == "📤" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📤" && storedSettings.isPremium === true) {
               emoji = "📤";
-            } else if (data.ticketReaction == "📨" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📨" && storedSettings.isPremium === true) {
               emoji = "📨";
-            } else if (data.ticketReaction == "🔑" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "🔑" && storedSettings.isPremium === true) {
               emoji = "🔑";
-            } else if (data.ticketReaction == "🏷️" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "🏷️" && storedSettings.isPremium === true) {
               emoji = "🏷️";
             } else {
               emoji = "🎫";
@@ -4373,7 +4373,7 @@ In the mean time, please explain your issue below`;
             if (data.ticketReaction == "ticketReaction1") emoji = "🎫";
             if (data.ticketReaction == "📩") emoji = "📩";
 
-            if (storedSettings.isPremium == "false") {
+            if (storedSettings.isPremium === false) {
 
               if (data.ticketReaction == "🎫" || data.ticketReaction == "📩") {
                 ticketSettings.ticketReaction = data.ticketReaction
@@ -4453,27 +4453,27 @@ In the mean time, please explain your issue below`;
             // get emoji reaction 
 
             let emoji = data.ticketReaction;
-            if (data.ticketReaction == "ticketReaction2" && storedSettings.isPremium == "true") {
+            if (data.ticketReaction == "ticketReaction2" && storedSettings.isPremium === true) {
               emoji = "🎟️";
-            } else if (data.ticketReaction == "✅" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "✅" && storedSettings.isPremium === true) {
               emoji = "✅";
-            } else if (data.ticketReaction == "📻" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📻" && storedSettings.isPremium === true) {
               emoji = "📻";
-            } else if (data.ticketReaction == "☑️" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "☑️" && storedSettings.isPremium === true) {
               emoji = "☑️";
-            } else if (data.ticketReaction == "📲" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📲" && storedSettings.isPremium === true) {
               emoji = "📲";
-            } else if (data.ticketReaction == "📟" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📟" && storedSettings.isPremium === true) {
               emoji = "📟";
-            } else if (data.ticketReaction == "🆕" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "🆕" && storedSettings.isPremium === true) {
               emoji = "🆕";
-            } else if (data.ticketReaction == "📤" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📤" && storedSettings.isPremium === true) {
               emoji = "📤";
-            } else if (data.ticketReaction == "📨" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "📨" && storedSettings.isPremium === true) {
               emoji = "📨";
-            } else if (data.ticketReaction == "🔑" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "🔑" && storedSettings.isPremium === true) {
               emoji = "🔑";
-            } else if (data.ticketReaction == "🏷️" && storedSettings.isPremium == "true") {
+            } else if (data.ticketReaction == "🏷️" && storedSettings.isPremium === true) {
               emoji = "🏷️";
             } else {
               emoji = "🎫";
@@ -4484,7 +4484,7 @@ In the mean time, please explain your issue below`;
             if (data.ticketReaction == "ticketReaction1") emoji = "🎫";
             if (data.ticketReaction == "📩") emoji = "📩";
 
-            if (storedSettings.isPremium == "false") {
+            if (storedSettings.isPremium === false) {
               if (data.ticketReaction == "🎫" || data.ticketReaction == "📩") {
                 ticketSettings.ticketReaction = data.ticketReaction
               } else {
@@ -4730,7 +4730,7 @@ if(maintenance && maintenance.toggle == "true") {
 
       if (Object.prototype.hasOwnProperty.call(data, "premium")) {
 
-        if (storedSettings.isPremium == "true") {
+        if (storedSettings.isPremium === true) {
 
           //color
           if (data.color) {
@@ -4970,7 +4970,7 @@ if(maintenance && maintenance.toggle == "true") {
 
         con = arrFiltered
 
-        if (storedSettings.isPremium == "false") {
+        if (storedSettings.isPremium === false) {
 
           if (con.length > 10) {
             renderTemplate(res, req, "./new/mainaltdetector.ejs", {
@@ -4982,7 +4982,7 @@ if(maintenance && maintenance.toggle == "true") {
             return;
           }
 
-        } else if (storedSettings.isPremium == "true") {
+        } else if (storedSettings.isPremium === true) {
 
           if (con.length > 50) {
             renderTemplate(res, req, "./new/mainaltdetector.ejs", {
@@ -5135,7 +5135,7 @@ if(maintenance && maintenance.toggle == "true") {
 
         if (checkDecline3) {
 
-          if (storedSettings.isPremium == "true") {
+          if (storedSettings.isPremium === true) {
             storedSettings.report.upvote = true;
 
             //reaction

--- a/dashboard/templates/new/mainpage.ejs
+++ b/dashboard/templates/new/mainpage.ejs
@@ -239,7 +239,7 @@
 </div>
 <div class="box4 box">
         <div class="containerB">
-        <% if(settings.isPremium === "true") { %>
+        <% if(settings.isPremium === true) { %>
                                                 <h3 class="bigText">Is Premium</h3>
                                                 <% } else { %>
 <h3 class="bigText">Not Premium</h3>

--- a/dashboard/templates/new/mainreactionroles.ejs
+++ b/dashboard/templates/new/mainreactionroles.ejs
@@ -172,7 +172,7 @@
         <div class="col-md-4">&nbsp;</div>
 
     <div class="col-md-4" style="text-align: center;  padding-bottom: 40px">
- RR Dms<% if(settings.isPremium == "false"){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %>
+ RR Dms<% if(settings.isPremium == false){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %>
   <div style="padding-top: 4px">
 <% if(settings.reactionDM === true) { %>
   <input id="s1" name="rrDM" type="checkbox" class="switch" checked>

--- a/dashboard/templates/new/mainreports.ejs
+++ b/dashboard/templates/new/mainreports.ejs
@@ -135,7 +135,7 @@
 <% } else { %>
 <input name="disableUser" class="input-switch" type="checkbox" id="switch2"></input><label class="label-switch"for="switch2">Toggle</label>
 <% } %>
-<p> <% if(settings.isPremium == "false"){ %>Enable report Upvotes <a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a></p>
+<p> <% if(settings.isPremium == false){ %>Enable report Upvotes <a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a></p>
 <% } else { %>
 <p>Enable report Upvotes</p>
 <% } %>

--- a/dashboard/templates/new/mainsuggestions.ejs
+++ b/dashboard/templates/new/mainsuggestions.ejs
@@ -162,7 +162,7 @@
     </div>
     
 <p style="background-color: #2f2f2f; color: #2f2f2f ">HELLOO :) you found a secret message, poggers</p>
-<% if(settings.isPremium == "false"){ %>
+<% if(settings.isPremium == false){ %>
 <div class="premium"><h1>This is a Premium Feature</h1>
 <button class="save-button" type="button" onclick="window.location.href='/premium'">Unlock Now!</button>
 </div>
@@ -268,7 +268,7 @@ max-height:200px; background-color: #2f2f2f; color: white;" ><%= settings.sugges
 <br>
 <button class="save-button" type="button">Save Changes</button>
 
-<% } else if(settings.isPremium == "true"){ %>
+<% } else if(settings.isPremium == true){ %>
 <div class="customize">
 <h2>Customize Your Embed</h2>
 <br>

--- a/dashboard/templates/new/maintickets.ejs
+++ b/dashboard/templates/new/maintickets.ejs
@@ -169,7 +169,7 @@ max-height:200px; min-height:60px; background-color: #2f2f2f; color: white;" id=
 
                                                     <% } else { %>
                                                       <input name="ticketClose" class="input-switch" type="checkbox" id="switch3"></input><label class="label-switch"for="switch3" checked>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-                                                    <% } %>Allow Users to Close ticket &nbsp;<% if(settings.isPremium == "false"){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %></p>
+                                                    <% } %>Allow Users to Close ticket &nbsp;<% if(settings.isPremium == false){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %></p>
 <br>
  </div> 
 <br>
@@ -228,7 +228,7 @@ max-height:200px; min-height:60px; background-color: #2f2f2f; color: white;" id=
 
              <% } else { %>
          <input name="reactionfooterEmbed" class="input-switch" type="checkbox" onclick="myFunction04()" id="reactionEmbedFooter" ></input><label class="label-switch"for="reactionEmbedFooter">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</label>
-         <% } %> &nbsp;Reaction Footer <% if(settings.isPremium == "false"){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %></p>                                                 
+         <% } %> &nbsp;Reaction Footer <% if(settings.isPremium == false){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %></p>                                                 
 
 <div id="reactionEmbedFooterID" style="display:none">
 <div class="user-box">
@@ -255,9 +255,9 @@ max-height:200px; min-height:60px; background-color: #2f2f2f; color: white;" id=
                                                 <% } %>
                                             </select>
 
-<p><bold>Ticket Reaction</bold> &nbsp;<% if(settings.isPremium == "false"){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %><p> 
+<p><bold>Ticket Reaction</bold> &nbsp;<% if(settings.isPremium == false){ %><a href="https://pogy.xyz/premium"><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i></a><% } %><p> 
 <select style="background-color: #2f2f2f; color: white; border-radius: 5px; "  name="ticketReaction" class="select">
-<% if(settings.isPremium == "false"){ %>
+<% if(settings.isPremium == false){ %>
 
 <% if(ticket.ticketReaction == "🎫"){ %>
 
@@ -602,10 +602,10 @@ max-height:200px; min-height:60px; background-color: #2f2f2f; color: white;" id=
       <input style="min-width: 180px;  max-width: 300px; background-color: #2f2f2f; color: white; border-radius: 5px; " class="form-control" type="text" name="messageID" value="<%= ticket.messageID[ticket.messageID.length - 1] %>" placeholder="message ID">
 </div>
 
-<p><bold>Ticket Reaction</bold> &nbsp;<% if(settings.isPremium == "false"){ %><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i><% } %></p> 
+<p><bold>Ticket Reaction</bold> &nbsp;<% if(settings.isPremium == false){ %><i style="font-size:14px; color: yellow" class="fa">&#xf006;</i><% } %></p> 
 
 <select style="background-color: #2f2f2f; color: white; border-radius: 5px; "  name="ticketReaction" class="select">
-<% if(settings.isPremium == "false"){ %>
+<% if(settings.isPremium == false){ %>
 
 <% if(ticket.ticketReaction == "🎫"){ %>
 

--- a/dashboard/templates/redeemguild.ejs
+++ b/dashboard/templates/redeemguild.ejs
@@ -5,7 +5,7 @@
     href="<%domain%>/logo.png">
     <body>
   
-  <% if(!alert && settings.isPremium === "true") { %>
+  <% if(!alert && settings.isPremium === true) { %>
    <div class="container-contact">
             <div class="wrap-contact">
                 

--- a/database/schemas/Guild.js
+++ b/database/schemas/Guild.js
@@ -17,7 +17,7 @@ const guildConfigSchema = mongoose.Schema({
     default: config.prefix || 'p!',
   },
   isPremium: {
-    type: mongoose.SchemaTypes.String,
+    type: mongoose.SchemaTypes.Boolean,
     required: false,
     default: false
   },

--- a/database/schemas/GuildPremium.js
+++ b/database/schemas/GuildPremium.js
@@ -4,12 +4,12 @@ const guildConfigSchema = mongoose.Schema({
 
 code: {type: mongoose.SchemaTypes.String, default: null},
 
-expiresAt: {type: mongoose.SchemaTypes.String, default: Date.now() + 2592000000},
+expiresAt: {type: mongoose.SchemaTypes.Number, default: () => Date.now() + 2592000000},
 
 plan: {type: mongoose.SchemaTypes.String, default: null},
 
 
-  
+
 
 });
 

--- a/events/reactions/messageReactionAdd.js
+++ b/events/reactions/messageReactionAdd.js
@@ -279,7 +279,7 @@ if(db.option === 2) {
       if(emoji.toString() === "🎫" || emoji.toString() === "🎟️" || emoji.toString() === "📩" ||emoji.toString() === "✅" ||emoji.toString() === "📻" ||emoji.toString() === "☑️" ||emoji.toString() === "📲" ||emoji.toString() === "📟" ||emoji.toString() === "🆕" ||emoji.toString() === "📤" ||emoji.toString() === "📨" ||emoji.toString() === "🔑"||emoji.toString() === "🏷️") {
 
 
-if(guildDB.isPremium == "false"){
+if(!guildDB.isPremium){
    if(emoji.toString() === "🎟️" ||emoji.toString() === "✅" ||emoji.toString() === "📻" ||emoji.toString() === "☑️" ||emoji.toString() === "📲" ||emoji.toString() === "📟" ||emoji.toString() === "🆕" ||emoji.toString() === "📤" ||emoji.toString() === "📨" ||emoji.toString() === "🔑"||emoji.toString() === "🏷️") return;
 }
         let serverCase = db.ticketCase;

--- a/events/shard/shardReady.js
+++ b/events/shard/shardReady.js
@@ -134,7 +134,7 @@ setInterval(async () => {
 
 
 const conditional = {
-    isPremium: "true",
+    isPremium: true,
 }
 const results = await Guild.find(conditional)
 
@@ -143,7 +143,7 @@ if (results && results.length) {
       
   
 
-       if (Number(result.premium.redeemedAt) >= Number(result.premium.expiresAt)) {
+       if (Date.now() >= Number(result.premium.expiresAt)) {
             
 
 const guildPremium = this.client.guilds.cache.get(result.guildId);
@@ -176,7 +176,7 @@ if(guildPremium){
       
 
 
-    result.isPremium = "false";
+    result.isPremium = false;
     result.premium.redeemedBy.id = null;
     result.premium.redeemedBy.tag = null;
     result.premium.redeemedAt = null;


### PR DESCRIPTION
## Summary
- Use dynamic expiration timestamp for premium codes
- Store guild premium flag as boolean and clean up checks
- Verify code expiration before redeeming and expire guilds based on current time

## Testing
- `npm test` *(fails: Missing script)*
- `npx --yes eslint "commands/alt detector/abypass.js" commands/applications/approve.js commands/applications/decline.js commands/config/autoresponse.js commands/config/customcommand.js commands/reactionrole/rrdirectmessages.js commands/utility/poll.js commands/utility/redeem.js commands/utility/report.js commands/utility/suggest.js dashboard/dashboard.js database/schemas/Guild.js database/schemas/GuildPremium.js events/reactions/messageReactionAdd.js events/shard/shardReady.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb10a678832e87c36f836f9c7bde