### PR TITLE
Allow premium code stacking and show remaining time

### DIFF
--- a/commands/utility/redeem.js
+++ b/commands/utility/redeem.js
@@ -2,6 +2,7 @@ const Command = require('../../structures/Command');
 const Guild = require('../../database/schemas/Guild');
 const Premium = require('../../database/schemas/GuildPremium');
 const moment = require("moment");
+require("moment-duration-format");
 const config = require('../../config.json');
 const Discord = require('discord.js');
 const webhookClient = new Discord.WebhookClient(config.webhook_id, config.webhook_url);
@@ -24,13 +25,9 @@ module.exports = class extends Command {
     
       const language = require(`../../data/language/${guildDB.language}.json`)
       
-   let code = args[0]
+   let code = args[0] ? args[0].toUpperCase() : null;
 
     if(!code) return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} Please Specify a code to redeem`))
-    
-    if (guildDB.isPremium) {
-      return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} the current guild is already premium`))
-    }
 
     const premium = await Premium.findOne({
       code: code
@@ -42,42 +39,60 @@ if (Number(premium.expiresAt) < Date.now()) {
   return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} This code has expired`))
 }
 
-const expires = moment(Number(premium.expiresAt)).format("dddd, MMMM Do YYYY HH:mm:ss")
+    const extension = Number(premium.expiresAt) - Date.now();
+    const alreadyPremium = guildDB.isPremium;
 
-
-    guildDB.isPremium = true;
     guildDB.premium.redeemedBy.id = message.author.id;
     guildDB.premium.redeemedBy.tag = message.author.tag;
-    guildDB.premium.redeemedAt = Date.now()
-    guildDB.premium.expiresAt = premium.expiresAt;
-    guildDB.premium.plan = premium.plan;
+    guildDB.premium.redeemedAt = Date.now();
 
-    await guildDB.save().catch(()=>{});
+    if (alreadyPremium) {
+      guildDB.premium.expiresAt = Number(guildDB.premium.expiresAt || Date.now()) + extension;
+    } else {
+      guildDB.isPremium = true;
+      guildDB.premium.expiresAt = premium.expiresAt;
+      guildDB.premium.plan = premium.plan;
+    }
 
-    await premium.deleteOne().catch(()=>{});
+    try {
+      await guildDB.save();
+    } catch (err) {
+      console.error("Failed to save premium data:", err);
+      return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} Failed to save premium data, please try again later.`));
+    }
+
+    try {
+      await premium.deleteOne();
+    } catch (err) {
+      console.error("Failed to delete premium code:", err);
+      return message.channel.send(new Discord.MessageEmbed().setColor('RED').setDescription(`${message.client.emoji.fail} Failed to redeem the premium code, please contact support.`));
+    }
+
+const expires = moment(Number(guildDB.premium.expiresAt)).format("dddd, MMMM Do YYYY HH:mm:ss");
+const remaining = moment.duration(Number(guildDB.premium.expiresAt) - Date.now()).format("D [days], H [hrs], m [mins], s [secs]");
 
 let ID = uniqid(undefined, `-${code}`);
 const date = require('date-and-time');
 const now = new Date();
-let DDate = date.format(now, 'YYYY/MM/DD HH:mm:ss');  
+let DDate = date.format(now, 'YYYY/MM/DD HH:mm:ss');
 
     try {
 await message.author.send(new Discord.MessageEmbed()
-    .setDescription(`**Premium Subscription**\n\nYou've recently redeemed a code in **${message.guild.name}** and here is your receipt:\n\n **Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${message.guild.name}\n**Guild ID:** ${message.guild.id}`)
+    .setDescription(`**Premium Subscription**\n\nYou've recently redeemed ${alreadyPremium ? 'an additional' : 'a'} code in **${message.guild.name}** and here is your receipt:\n\n **Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${message.guild.name}\n**Guild ID:** ${message.guild.id}\n**Expires At:** ${expires}\n**Remaining:** ${remaining}`)
       .setColor(message.guild.me.displayHexColor)
       .setFooter(message.guild.name))
     } catch (err){
 console.log(err)
- message.channel.send(new Discord.MessageEmbed().setDescription(`**Congratulations!**\n\n**${message.guild.name}** Is now a premium guild! Thanks a ton!\n\nIf you have any questions please contact me [here](https://discord.gg/duBwdCvCwW)\n\n**Could not send your Reciept via dms so here it is:**\n**Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${message.guild.name}\n**Guild ID:** ${message.guild.id}\n\n**Please make sure to keep this information safe, you might need it if you ever wanna refund / transfer servers.**\n\n**Expires At:** ${expires}`).setColor(message.guild.me.displayHexColor).setFooter(message.guild.name));
-     
+ message.channel.send(new Discord.MessageEmbed().setDescription(`**Congratulations!**\n\n**${message.guild.name}** ${alreadyPremium ? 'premium has been extended!' : 'Is now a premium guild! Thanks a ton!'}\n\nIf you have any questions please contact me [here](https://discord.gg/duBwdCvCwW)\n\n**Could not send your Reciept via dms so here it is:**\n**Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${message.guild.name}\n**Guild ID:** ${message.guild.id}\n\n**Please make sure to keep this information safe, you might need it if you ever wanna refund / transfer servers.**\n\n**Expires At:** ${expires}\n**Remaining:** ${remaining}`).setColor(message.guild.me.displayHexColor).setFooter(message.guild.name));
+
       return;
     }
-   
 
-    message.channel.send(new Discord.MessageEmbed().setDescription(`**Congratulations!**\n\n**${message.guild.name}** Is now a premium guild! Thanks a ton!\n\nIf you have any questions please contact me [here](https://discord.gg/FqdH4sfKBg)\n**your receipt has been sent via dms**\n\n**Expires At:** ${expires}`).setColor(message.guild.me.displayHexColor).setFooter(message.guild.name));
+
+    message.channel.send(new Discord.MessageEmbed().setDescription(`**Congratulations!**\n\n**${message.guild.name}** ${alreadyPremium ? 'premium has been extended!' : 'Is now a premium guild! Thanks a ton!'}\n\nIf you have any questions please contact me [here](https://discord.gg/FqdH4sfKBg)\n**your receipt has been sent via dms**\n\n**Expires At:** ${expires}\n**Remaining:** ${remaining}`).setColor(message.guild.me.displayHexColor).setFooter(message.guild.name));
 
 const embedPremium = new Discord.MessageEmbed()
-      .setDescription(`**Premium Subscription**\n\n**${message.author.tag}** Redeemed a code in **${message.guild.name}**\n\n **Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${message.guild.name}\n**Guild ID:** ${message.guild.id}\n**Redeemer Tag:** ${message.author.tag}\n**Redeemer ID:** ${message.author.id}\n\n**Expires At:** ${expires}`)
+      .setDescription(`**Premium Subscription**\n\n**${message.author.tag}** Redeemed ${alreadyPremium ? 'an additional' : 'a'} code in **${message.guild.name}**\n\n **Reciept ID:** ${ID}\n**Redeem Date:** ${DDate}\n**Guild Name:** ${message.guild.name}\n**Guild ID:** ${message.guild.id}\n**Redeemer Tag:** ${message.author.tag}\n**Redeemer ID:** ${message.author.id}\n\n**Expires At:** ${expires}\n**Remaining:** ${remaining}`)
       .setColor(message.guild.me.displayHexColor)
 
 webhookClient.send({


### PR DESCRIPTION
## Summary
- normalize redeemed codes to uppercase
- allow existing premium guilds to extend time by redeeming additional codes
- wrap database writes in try/catch and report failures
- show remaining premium duration in confirmations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a74886cab0832e949f7d45e2766a60