### PR TITLE
feat: add premium-only command middleware

### DIFF
--- a/commands/applications/approve.js
+++ b/commands/applications/approve.js
@@ -15,7 +15,8 @@ module.exports = class extends Command {
       description: "Approve an application in the guild.",
       cooldown: 5,
       userPermission: ['MANAGE_GUILD'],
-      botPermission: ['MANAGE_ROLES']
+      botPermission: ['MANAGE_ROLES'],
+      premiumOnly: true
     })
   }
   async run(message, args) {
@@ -24,13 +25,6 @@ module.exports = class extends Command {
         guildId: message.guild.id
     });
     const language = require(`../../data/language/${guildDB.language}.json`)
-    
-    if(!guildDB.isPremium){
-
-message.channel.send(new discord.MessageEmbed().setColor(message.guild.me.displayHexColor).setDescription(`${message.client.emoji.fail} | ${language.approvepremium}.\n\n[Check Premium Here](https://pogy.xyz/premium)`))
-
-      return;
-    }
    let app = await App.findOne({
       guildID: message.guild.id
     });
@@ -100,3 +94,4 @@ member.send(new discord.MessageEmbed().setColor(message.client.color.green).setT
  
   }
 }
+

--- a/commands/applications/decline.js
+++ b/commands/applications/decline.js
@@ -14,7 +14,8 @@ module.exports = class extends Command {
       description: "Decline an application in the guild.",
       cooldown: 5,
       userPermission: ['MANAGE_GUILD'],
-      botPermission: ['MANAGE_ROLES']
+      botPermission: ['MANAGE_ROLES'],
+      premiumOnly: true
     })
   }
  async run(message, args) {
@@ -24,12 +25,6 @@ module.exports = class extends Command {
         guildId: message.guild.id
     });
     const language = require(`../../data/language/${guildDB.language}.json`)
-        if(!guildDB.isPremium){
-
-message.channel.send(new discord.MessageEmbed().setColor(message.guild.me.displayHexColor).setDescription(`${message.client.emoji.fail} | ${language.approvepremium}.\n\n[Check Premium Here](https://pogy.xyz/premium)`))
-
-      return;
-    }
      let member = message.mentions.members.last()
  
      
@@ -102,3 +97,4 @@ member.send(new discord.MessageEmbed().setColor(message.client.color.red).setTit
  
   }
 }
+

--- a/commands/reactionrole/rrdirectmessages.js
+++ b/commands/reactionrole/rrdirectmessages.js
@@ -17,6 +17,7 @@ module.exports = class extends Command {
         cooldown: 3,
         usage: 'on / off',
         userPermission: ['MANAGE_GUILD'],
+        premiumOnly: true,
       });
     }
 
@@ -33,9 +34,6 @@ module.exports = class extends Command {
       let fail = message.client.emoji.fail
       let success = message.client.emoji.success
       const prefix = guildDB.prefix;
-
-      if(!guildDB.isPremium){
-      return message.channel.send(new MessageEmbed().setColor(message.guild.me.displayHexColor).setDescription(`${fail} Slow down here, the current command is only for premium guilds.\n\n[Check Premium Here](https://pogy.xyz/premium)`))}
 
   const missingPermEmbed = new MessageEmbed()
   .setAuthor(`Missing User Permissions`, message.author.displayAvatarURL())

--- a/events/message/message.js
+++ b/events/message/message.js
@@ -379,6 +379,12 @@ return message.channel.send(embed)
           if (!this.client.config.developers.includes(message.author.id)) return
         }
 
+        if (command.premiumOnly && !guildDB.isPremium) {
+          return message.channel.send(new MessageEmbed()
+            .setColor(message.guild.me.displayHexColor)
+            .setDescription(`${message.client.emoji.fail} Slow down here, the current command is only for premium guilds.\n\n[Check Premium Here](https://pogy.xyz/premium)`));
+        }
+
 if(config.datadogApiKey){
        metrics.increment('commands_served');
 }

--- a/structures/Command.js
+++ b/structures/Command.js
@@ -14,9 +14,10 @@ module.exports = class Command {
         this.ownerOnly = options.ownerOnly || false;
         this.guildOnly = options.guildOnly || false;
         this.nsfwOnly = options.nsfwOnly || false;
+        this.premiumOnly = options.premiumOnly || false;
         this.botPermission = options.botPermission || ['SEND_MESSAGES', 'EMBED_LINKS'];
         this.userPermission = options.userPermission  || null;
-        
+
     }
 
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
## Summary
- add `premiumOnly` flag to Command base
- guard premium commands with middleware
- convert existing premium checks to use middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint structures/Command.js events/message/message.js commands/reactionrole/rrdirectmessages.js commands/applications/decline.js commands/applications/approve.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a74887ac70832e943b3c8ff0d3ca35